### PR TITLE
Add support for BLE temp sensors

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -58,6 +58,7 @@ extra_scripts =
 build_flags = 
 	${env.build_flags}
 	-D CORE_DEBUG_LEVEL=0
+	-D USE_BLE=1
 
 
 ; Boards

--- a/platformio.ini
+++ b/platformio.ini
@@ -50,6 +50,7 @@ platform = espressif32
 lib_deps =
 	${env.lib_deps}
 	laxilef/ESP32Scheduler@^1.0.1
+	h2zero/NimBLE-Arduino@^1.4.1
 lib_ignore = 
 extra_scripts = 
 	post:tools/esp32.py
@@ -174,6 +175,7 @@ board = wemos_d1_mini32
 lib_deps = ${esp32_defaults.lib_deps}
 lib_ignore = ${esp32_defaults.lib_ignore}
 extra_scripts = ${esp32_defaults.extra_scripts}
+;board_build.partitions = huge_app.csv
 build_flags = 
 	${esp32_defaults.build_flags}
 	-D OT_IN_PIN_DEFAULT=21

--- a/src/HaHelper.h
+++ b/src/HaHelper.h
@@ -29,16 +29,17 @@ public:
   bool publishSelectIndoorSensorType(bool enabledByDefault = true) {
     StaticJsonDocument<1536> doc;
     doc[FPSTR(HA_COMMAND_TOPIC)] = devicePrefix + F("/settings/set");
-    doc[FPSTR(HA_COMMAND_TEMPLATE)] = F("{\"sensors\": {\"indoor\": {\"type\": {% if value == 'Manual' %}1{% elif value == 'External' %}2{% endif %}}}}");
+    doc[FPSTR(HA_COMMAND_TEMPLATE)] = F("{\"sensors\": {\"indoor\": {\"type\": {% if value == 'Manual' %}1{% elif value == 'External' %}2{% elif value == 'Bluetooth' %}3{% endif %}}}}");
     doc[FPSTR(HA_ENABLED_BY_DEFAULT)] = enabledByDefault;
     doc[FPSTR(HA_UNIQUE_ID)] = devicePrefix + F("_indoor_sensor_type");
     doc[FPSTR(HA_OBJECT_ID)] = devicePrefix + F("_indoor_sensor_type");
     doc[FPSTR(HA_ENTITY_CATEGORY)] = F("config");
     doc[FPSTR(HA_NAME)] = F("Indoor temperature source");
     doc[FPSTR(HA_STATE_TOPIC)] = devicePrefix + F("/settings");
-    doc[FPSTR(HA_VALUE_TEMPLATE)] = F("{% if value_json.sensors.indoor.type == 1 %}Manual{% elif value_json.sensors.indoor.type == 2 %}External{% endif %}");
+    doc[FPSTR(HA_VALUE_TEMPLATE)] = F("{% if value_json.sensors.indoor.type == 1 %}Manual{% elif value_json.sensors.indoor.type == 2 %}External{% elif value_json.sensors.indoor.type == 3 %}Bluetooth{% endif %}");
     doc[FPSTR(HA_OPTIONS)][0] = F("Manual");
     doc[FPSTR(HA_OPTIONS)][1] = F("External");
+    doc[FPSTR(HA_OPTIONS)][2] = F("Bluetooth");
 
     return publish(getTopic("select", "indoor_sensor_type").c_str(), doc);
   }

--- a/src/MqttTask.h
+++ b/src/MqttTask.h
@@ -290,7 +290,7 @@ protected:
     }
 
     if (!doc["sensors"]["indoor"]["type"].isNull() && doc["sensors"]["indoor"]["type"].is<unsigned char>()) {
-      if (doc["sensors"]["indoor"]["type"].as<unsigned char>() >= 1 && doc["sensors"]["indoor"]["type"].as<unsigned char>() <= 2) {
+      if (doc["sensors"]["indoor"]["type"].as<unsigned char>() >= 1 && doc["sensors"]["indoor"]["type"].as<unsigned char>() <= 3) {
         settings.sensors.indoor.type = doc["sensors"]["indoor"]["type"].as<unsigned char>();
         flag = true;
       }

--- a/src/OpenThermTask.h
+++ b/src/OpenThermTask.h
@@ -394,7 +394,7 @@ protected:
   }
 
   bool updateSlaveConfig() {
-    unsigned long response = ot->sendRequest(ot->buildRequest(OpenThermRequestType::READ, OpenThermMessageID::SConfigSMemberIDcode, 0));
+    unsigned long response = ot->sendRequest(ot->buildRequest(OpenThermRequestType::READ_DATA, OpenThermMessageID::SConfigSMemberIDcode, 0));
     if (!ot->isValidResponse(response)) {
       return false;
     }
@@ -451,7 +451,7 @@ protected:
     }
 
     unsigned long response = ot->sendRequest(ot->buildRequest(
-      OpenThermRequestType::WRITE,
+      OpenThermRequestType::WRITE_DATA,
       OpenThermMessageID::MConfigMMemberIDcode,
       request
     ));
@@ -461,7 +461,7 @@ protected:
 
   bool setMaxModulationLevel(byte value) {
     unsigned long response = ot->sendRequest(ot->buildRequest(
-      OpenThermRequestType::WRITE,
+      OpenThermRequestType::WRITE_DATA,
       OpenThermMessageID::MaxRelModLevelSetting,
       ot->toF88(value)
     ));
@@ -475,7 +475,7 @@ protected:
   }
 
   bool updateSlaveOtVersion() {
-    unsigned long response = ot->sendRequest(ot->buildRequest(OpenThermRequestType::READ, OpenThermMessageID::OpenThermVersionSlave, 0));
+    unsigned long response = ot->sendRequest(ot->buildRequest(OpenThermRequestType::READ_DATA, OpenThermMessageID::OpenThermVersionSlave, 0));
     if (!ot->isValidResponse(response)) {
       return false;
     }
@@ -501,7 +501,7 @@ protected:
   }
 
   bool updateSlaveVersion() {
-    unsigned long response = ot->sendRequest(ot->buildRequest(OpenThermRequestType::READ, OpenThermMessageID::SlaveVersion, 0));
+    unsigned long response = ot->sendRequest(ot->buildRequest(OpenThermRequestType::READ_DATA, OpenThermMessageID::SlaveVersion, 0));
     if (!ot->isValidResponse(response)) {
       return false;
     }
@@ -514,7 +514,7 @@ protected:
 
   bool setMasterVersion(uint8_t version, uint8_t type) {
     unsigned long response = ot->sendRequest(ot->buildRequest(
-      OpenThermRequestType::WRITE,
+      OpenThermRequestType::WRITE_DATA,
       OpenThermMessageID::MasterVersion,
       (unsigned int) version | (unsigned int) type << 8 // 0x013F
     ));
@@ -530,7 +530,7 @@ protected:
   }
 
   bool updateMinMaxDhwTemp() {
-    unsigned long response = ot->sendRequest(ot->buildRequest(OpenThermRequestType::READ, OpenThermMessageID::TdhwSetUBTdhwSetLB, 0));
+    unsigned long response = ot->sendRequest(ot->buildRequest(OpenThermRequestType::READ_DATA, OpenThermMessageID::TdhwSetUBTdhwSetLB, 0));
     if (!ot->isValidResponse(response)) {
       return false;
     }
@@ -549,7 +549,7 @@ protected:
   }
 
   bool updateMinMaxHeatingTemp() {
-    unsigned long response = ot->sendRequest(ot->buildRequest(OpenThermRequestType::READ, OpenThermMessageID::MaxTSetUBMaxTSetLB, 0));
+    unsigned long response = ot->sendRequest(ot->buildRequest(OpenThermRequestType::READ_DATA, OpenThermMessageID::MaxTSetUBMaxTSetLB, 0));
     if (!ot->isValidResponse(response)) {
       return false;
     }
@@ -576,7 +576,7 @@ protected:
   }
 
   bool updateOutsideTemp() {
-    unsigned long response = ot->sendRequest(ot->buildRequest(OpenThermRequestType::READ, OpenThermMessageID::Toutside, 0));
+    unsigned long response = ot->sendRequest(ot->buildRequest(OpenThermRequestType::READ_DATA, OpenThermMessageID::Toutside, 0));
     if (!ot->isValidResponse(response)) {
       return false;
     }
@@ -597,7 +597,7 @@ protected:
 
 
   bool updateDhwTemp() {
-    unsigned long response = ot->sendRequest(ot->buildRequest(OpenThermMessageType::READ, OpenThermMessageID::Tdhw, 0));
+    unsigned long response = ot->sendRequest(ot->buildRequest(OpenThermMessageType::READ_DATA, OpenThermMessageID::Tdhw, 0));
     if (!ot->isValidResponse(response)) {
       return false;
     }
@@ -607,7 +607,7 @@ protected:
   }
 
   bool updateDhwFlowRate() {
-    unsigned long response = ot->sendRequest(ot->buildRequest(OpenThermMessageType::READ, OpenThermMessageID::DHWFlowRate, 0));
+    unsigned long response = ot->sendRequest(ot->buildRequest(OpenThermMessageType::READ_DATA, OpenThermMessageID::DHWFlowRate, 0));
     if (!ot->isValidResponse(response)) {
       return false;
     }
@@ -617,7 +617,7 @@ protected:
   }
 
   bool updateFaultCode() {
-    unsigned long response = ot->sendRequest(ot->buildRequest(OpenThermRequestType::READ, OpenThermMessageID::ASFflags, 0));
+    unsigned long response = ot->sendRequest(ot->buildRequest(OpenThermRequestType::READ_DATA, OpenThermMessageID::ASFflags, 0));
 
     if (!ot->isValidResponse(response)) {
       return false;
@@ -628,7 +628,7 @@ protected:
   }
 
   bool updateModulationLevel() {
-    unsigned long response = ot->sendRequest(ot->buildRequest(OpenThermRequestType::READ, OpenThermMessageID::RelModLevel, 0));
+    unsigned long response = ot->sendRequest(ot->buildRequest(OpenThermRequestType::READ_DATA, OpenThermMessageID::RelModLevel, 0));
 
     if (!ot->isValidResponse(response)) {
       return false;
@@ -645,7 +645,7 @@ protected:
   }
 
   bool updatePressure() {
-    unsigned long response = ot->sendRequest(ot->buildRequest(OpenThermRequestType::READ, OpenThermMessageID::CHPressure, 0));
+    unsigned long response = ot->sendRequest(ot->buildRequest(OpenThermRequestType::READ_DATA, OpenThermMessageID::CHPressure, 0));
 
     if (!ot->isValidResponse(response)) {
       return false;

--- a/src/SensorsTask.h
+++ b/src/SensorsTask.h
@@ -1,7 +1,7 @@
 #include <OneWire.h>
 #include <DallasTemperature.h>
 
-#if defined(ESP32)
+#if USE_BLE
   #include <NimBLEDevice.h>
 
   // BLE services and characterstics that we are interested in
@@ -37,7 +37,7 @@ protected:
   float filteredIndoorTemp = 0;
   bool emptyIndoorTemp = true;
 
-#if defined(ESP32)
+#if USE_BLE
   BLEClient* pBleClient = nullptr;
   BLERemoteService* pBleServiceBattery = nullptr;
   BLERemoteService* pBleServiceEnvironment = nullptr;
@@ -64,12 +64,14 @@ protected:
     if (settings.sensors.indoor.type == 2 && settings.sensors.indoor.pin) {
       indoorTemperatureSensor();
     }
-#if defined(ESP32)
+#if USE_BLE
     else if (settings.sensors.indoor.type == 3 && strlen(settings.sensors.indoor.bleAddresss)) {
       bluetoothSensor();
     }
+#endif
   }
 
+#if USE_BLE
   void bluetoothSensor() {
     if (!initBleSensor && millis() > 5000) {
       Log.sinfoln(FPSTR(S_SENSORS_BLE), "Init BLE. Free heap %u bytes", ESP.getFreeHeap());

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -72,9 +72,10 @@ struct Settings {
     } outdoor;
 
     struct {
-      // 1 - manual, 2 - ds18b20
+      // 1 - manual, 2 - ds18b20, 3 - ble
       byte type = 1;
       byte pin = SENSOR_INDOOR_PIN_DEFAULT;
+      char bleAddresss[18];
       float offset = 0.0f;
     } indoor;
   } sensors;

--- a/src/WifiManagerTask.h
+++ b/src/WifiManagerTask.h
@@ -174,9 +174,6 @@ protected:
     wmBleAddress = new WiFiManagerParameter("ble_address", "BLE sensor address", settings.sensors.indoor.bleAddresss, 17);
     wm.addParameter(wmBleAddress);
 
-    wmBleAddress = new WiFiManagerParameter("ble_address", "BLE sensor address", settings.sensors.indoor.bleAddresss, 17);
-    wm.addParameter(wmBleAddress);
-
     wmExtPumpHeader = new HeaderParameter("External pump");
     wm.addParameter(wmExtPumpHeader);
 

--- a/src/WifiManagerTask.h
+++ b/src/WifiManagerTask.h
@@ -28,6 +28,7 @@ CheckboxParameter* wmOtModSyncWithHeating;
 
 UnsignedIntParameter* wmOutdoorSensorPin;
 UnsignedIntParameter* wmIndoorSensorPin;
+WiFiManagerParameter* wmBleAddress;
 
 CheckboxParameter* wmExtPumpUse;
 UnsignedIntParameter* wmExtPumpPin;
@@ -152,6 +153,9 @@ protected:
 
     wmIndoorSensorPin = new UnsignedIntParameter("indoor_sensor_pin", "Indoor sensor GPIO", settings.sensors.indoor.pin, 2);
     wm.addParameter(wmIndoorSensorPin);
+
+    wmBleAddress = new WiFiManagerParameter("ble_address", "BLE sensor address", settings.sensors.indoor.bleAddresss, 17);
+    wm.addParameter(wmBleAddress);
 
     wm.addParameter(wmSep);
 
@@ -425,6 +429,13 @@ protected:
       settings.sensors.indoor.pin = wmIndoorSensorPin->getValue();
 
       Log.sinfoln(FPSTR(S_WIFI_SETTINGS), F("New sensors.indoor.pin: %hhu"), settings.sensors.indoor.pin);
+    }
+
+    if (strcmp(wmBleAddress->getValue(), settings.sensors.indoor.bleAddresss) != 0) {
+      changed = true;
+      strcpy(settings.sensors.indoor.bleAddresss, wmBleAddress->getValue());
+
+      Log.sinfoln(FPSTR(S_WIFI_SETTINGS), F("New BLE address: %s"), settings.sensors.indoor.bleAddresss);
     }
 
     if (wmExtPumpUse->getCheckboxValue() != settings.externalPump.use) {

--- a/src/defines.h
+++ b/src/defines.h
@@ -34,6 +34,10 @@
   #define USE_TELNET true
 #endif
 
+#ifndef USE_BLE
+  #define USE_BLE false
+#endif
+
 #ifndef DEBUG_BY_DEFAULT
   #define DEBUG_BY_DEFAULT false
 #endif


### PR DESCRIPTION
* BLE sensor address can be configured in Wifi Config, in the form `a4:c1:38:a6:73:b0` 
* Additional indoor temperature source can be configured in MQTT
* BLE sensor temperature, humidity and battery level are retrieved (only the first used)
* BLE sensor scanning during configuration can be added later