### PR TITLE
Filter default values 85 ​​for Dallas sensors

### DIFF
--- a/src/SensorsTask.h
+++ b/src/SensorsTask.h
@@ -350,10 +350,16 @@ protected:
           
           auto& rSensor = Sensors::results[sensorId];
           float value = instance.getTempC(sSensor.address);
-          if (value == DEVICE_DISCONNECTED_C) {
+          
+          Log.straceln(
+            FPSTR(L_SENSORS_DALLAS), F("GPIO %hhu, sensor #%hhu '%s', received data: %.2f"),
+            sSensor.gpio, sensorId, sSensor.name, value
+          );
+
+          if (value == DEVICE_DISCONNECTED_C || value == DALLAS_DEFAULT_REGVAL_C) {
             Log.swarningln(
-              FPSTR(L_SENSORS_DALLAS), F("GPIO %hhu, sensor #%hhu '%s': failed receiving data"),
-              sSensor.gpio, sensorId, sSensor.name
+              FPSTR(L_SENSORS_DALLAS), F("GPIO %hhu, sensor #%hhu '%s': failed receiving data, code: %.2f"),
+              sSensor.gpio, sensorId, sSensor.name, value
             );
 
             if (rSensor.signalQuality > 0) {
@@ -363,10 +369,7 @@ protected:
             continue;
           }
 
-          Log.straceln(
-            FPSTR(L_SENSORS_DALLAS), F("GPIO %hhu, sensor #%hhu '%s', received data: %.2f"),
-            sSensor.gpio, sensorId, sSensor.name, value
-          );
+
 
           if (rSensor.signalQuality < 100) {
             rSensor.signalQuality++;

--- a/src/defines.h
+++ b/src/defines.h
@@ -26,6 +26,8 @@
 #define DEFAULT_NTC_VLOW_TRESHOLD       25.0f
 #define DEFAULT_NTC_VHIGH_TRESHOLD      3298.0f
 
+#define DALLAS_DEFAULT_REGVAL_C         85
+
 #ifndef BUILD_VERSION
   #define BUILD_VERSION                 "0.0.0"
 #endif


### PR DESCRIPTION
Some sensors, for various reasons (wiring, power supply), return the default register value of 85 instead of the decoded temperature. This is described in the datasheet.

Such values ​​occur several times a day, sometimes not at all. At first, I thought it was interference. These values ​​cannot be removed using the noise removal algorithm. I had to give up autonomy and filter the values through the HA.

I have two boilers and four sensors from the same batch. I may need to replace the wiring. But such values ​​are common, and sending them to the MQTT is incorrect.

<img width="580" height="636" alt="1" src="https://github.com/user-attachments/assets/a56f2fcf-6a0d-4243-95ac-d0f7d0321856" />
<img width="578" height="676" alt="2" src="https://github.com/user-attachments/assets/e651bab4-395b-4a60-b047-6c5811ed6883" />

This was discussed for example here [https://forums.raspberrypi.com/viewtopic.php?t=63085](https://forums.raspberrypi.com/viewtopic.php?t=63085)
